### PR TITLE
G1 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To upgrade the CUDA version on a Linux machine please follow these general steps
 2. Download and install the new driver
 3. Install the CUDA toolkit
 
-To upgrade CUDA to version 12.2 on **Ubuntu 20.04** OS please follow these steps:
+To upgrade CUDA to version 12.3 on **Ubuntu 20.04** OS please follow these steps:
 
 1. Run `$ nvidia-smi` command to check for CUDA version (should be 10.1)
 2. Delete an old NVIDIA installation with
@@ -126,12 +126,12 @@ To upgrade CUDA to version 12.2 on **Ubuntu 20.04** OS please follow these steps
 sudo apt-get --purge remove "*nvidia*"
 ```
 
-3. Find the driver needed on the nvidia drivers page (https://www.nvidia.com/en-us/drivers/unix/). The link "Latest Production Branch Version: 535.129.03" will yield CUDA version 12.2. Place the downloaded file onto your machine.
+3. Find the driver needed on the nvidia drivers page (https://www.nvidia.com/en-us/drivers/unix/). The link "Latest Production Branch Version: 535.146.02" will yield CUDA version 12.3 (latest as of writing, January 2024). Place the downloaded file onto your machine.
 4. Install the driver and CUDA with: 
 
 ```shell
-chmod +x NVIDIA-Linux-x86_64-535.113.01.run
-sudo ./NVIDIA-Linux-x86_64-535.113.01.run
+chmod +x NVIDIA-Linux-x86_64-535.146.02.run
+sudo ./NVIDIA-Linux-x86_64-535.146.02.run
 ```
 
 ### 5. Install CUDA Toolkit
@@ -173,7 +173,7 @@ sudo systemctl restart docker
 
 Run `$ nvidia-smi` command to check for the new CUDA version to ensure it's been upgraded.
 
-### 6. Start the jupyter, fastapi, and streamlit services
+### 6. Start the JupyterLab, FastAPI, and Streamlit services
 
 Clone the repo into your VM:
 
@@ -181,7 +181,7 @@ Clone the repo into your VM:
 git clone https://github.com/cybera/text2img.git
 ```
 
-Source the HuggingFace AUTH_TOKEN as an environment variable in your terminal 
+Source the Hugging Face AUTH_TOKEN as an environment variable in your terminal 
 ```
 export AUTH_TOKEN=''
 ```
@@ -194,7 +194,7 @@ AUTH_TOKEN='<hugging face token>'
 
 into it. If following this approach, remember to `source` to restart your shell, or open a new terminal.
 
-Note: If this is your first time using HuggingFace models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`. 
+Note: If this is your first time using Hugging Face models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`. 
 
 Then, get the running instance of all the docker services by
 
@@ -209,7 +209,7 @@ After the succesful build, we can access the running services using the followin
 |Service |URL|
 |-----|--------|
 |JupyterLab|http://localhost:8888/|
-|FAST API  |http://localhost:8000/docs|
+|FastAPI  |http://localhost:8000/docs|
 |Streamlit  |http://localhost:8501/app|
 
 1. If you are running this on a remote cloud server, make sure to do relevant port forwarding

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sudo mkdir /mnt/<mount_point_name>
 Mount the volume device to the mount point:
 
 ```shell
-sudo mount /dev/sd<mount_point_name> /mnt/<mount_point_name>
+sudo mount /dev/<mount_point_name> /mnt/<mount_point_name>
 ```
 
 Permissions may need to be changed on the new volume, as they are initially set to root:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
-and run the file with `$ sh install_docker.sh`. 
+and run the file with `$ sh install_docker.sh`.
 
 To ensure the `docker` command can be accessed without `sudo`, run the following commands:
 
@@ -65,7 +65,7 @@ Format the volume:
 sudo mkfs.ext4 /dev/sdc
 ```
 
-List all disks from within the instance with: 
+List all disks from within the instance with:
 
 ```shell
 sudo fdisk -l
@@ -73,7 +73,7 @@ sudo fdisk -l
 
 Look for the disk corresponding to the volume with the assigned amount of space. It will be either `/dev/sdb` or `/dev/sdc`. Remember whether 'b' or 'c' applies here, and use that in place of `<mount_point_name>` below.
 
-Create a mount point for the volume: 
+Create a mount point for the volume:
 
 ```shell
 sudo mkdir /mnt/<mount_point_name>
@@ -85,7 +85,7 @@ Mount the volume device to the mount point:
 sudo mount /dev/sd<mount_point_name> /mnt/<mount_point_name>
 ```
 
-Permissions may need to be changed on the new volume, as they are initially set to root: 
+Permissions may need to be changed on the new volume, as they are initially set to root:
 
 ```shell
 sudo chown ubuntu:ubuntu /mnt/<mount_point_name>
@@ -109,7 +109,7 @@ sudo service docker restart
 
 > &#x26a0; This section can optionally be done for g2.\* and g3.\* instances and will improve performance, but needs to be skipped for g1.\* instances.
 
-Upgrading the CUDA version may enable running newer images on the RAC GPU instance. 
+Upgrading the CUDA version may enable running newer images on the RAC GPU instance.
 
 To upgrade the CUDA version on a Linux machine please follow these general steps:
 
@@ -126,8 +126,8 @@ To upgrade CUDA to version 12.3 on **Ubuntu 20.04** OS please follow these steps
 sudo apt-get --purge remove "*nvidia*"
 ```
 
-3. Find the driver needed on the nvidia drivers page (https://www.nvidia.com/en-us/drivers/unix/). The link "Latest Production Branch Version: 535.146.02" will yield CUDA version 12.3 (latest as of writing, January 2024). Place the downloaded file onto your machine.
-4. Install the driver and CUDA with: 
+3. Find the driver needed on the [NVIDIA drivers page](https://www.nvidia.com/en-us/drivers/unix/). The link "Latest Production Branch Version: 535.146.02" will yield CUDA version 12.3 (latest as of writing, January 2024). Place the downloaded file onto your machine.
+4. Install the driver and CUDA with:
 
 ```shell
 chmod +x NVIDIA-Linux-x86_64-535.146.02.run
@@ -136,7 +136,7 @@ sudo ./NVIDIA-Linux-x86_64-535.146.02.run
 
 ### 5. Install CUDA Toolkit
 
-Install the CUDA toolkit by following the steps in 'Installing with Apt' and then the steps in 'Configuring Docker' sections found at https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+Install the CUDA toolkit by following the steps in 'Installing with Apt' and then the steps in 'Configuring Docker' sections found on the [NVIDIA website](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 
 Configure the production repository:
 
@@ -181,8 +181,9 @@ Clone the repo into your VM:
 git clone https://github.com/cybera/text2img.git
 ```
 
-Source the Hugging Face AUTH_TOKEN as an environment variable in your terminal 
-```
+Source the Hugging Face AUTH_TOKEN as an environment variable in your terminal
+
+```shell
 export AUTH_TOKEN=''
 ```
 
@@ -194,7 +195,7 @@ AUTH_TOKEN='<hugging face token>'
 
 into it. If following this approach, remember to `source` to restart your shell, or open a new terminal.
 
-Note: If this is your first time using Hugging Face models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`. 
+Note: If this is your first time using Hugging Face models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`.
 
 Then, get the running instance of all the docker services by
 
@@ -217,6 +218,7 @@ After the succesful build, we can access the running services using the followin
 2. The default password for accessing the running instance for JupyterLab container is `gpu-jupyter`
 
 ### References
+
 1. [Set up Your own GPU-based Jupyter easily using Docker](https://cschranz.medium.com/set-up-your-own-gpu-based-jupyterlab-e0d45fcacf43)
 2. [Stable Diffusion with 🧨 Diffusers](https://huggingface.co/blog/stable_diffusion)
 3. [DeepLearning AI: FastAPI for Machine Learning: Live coding an ML web application](https://www.youtube.com/watch?v=_BZGtifh_gw)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # text2img
 
-This repository is part of the workshop covered under the [Applied Data Science Lab (ADSL)](https://www.cybera.ca/adsl/) program.
+This repository is part of the workshop covered under the <a href="https://www.cybera.ca/adsl/" target="_blank">Applied Data Science Lab</a> program.
 
 This workshop utilizes the stable diffusion method to generate images from text prompts.
 
@@ -15,15 +15,15 @@ This guide is organized as:
 
 ### 1. Start a Rapid Access Cloud (RAC) GPU instance
 
-Sign up for a RAC account from the [RAC portal](https://rac-portal.cybera.ca/users/sign_in). Ensure you're accessing RAC from the Edmonton region, then Launch a RAC GPU instance and ensure you are able to use `$ ssh` to access the instance.
+Sign up for a RAC account from the <a href="https://rac-portal.cybera.ca/users/sign_in" target="_blank">RAC portal</a>. Ensure you're accessing RAC from the Edmonton region, then Launch a RAC GPU instance and ensure you are able to use `$ ssh` to access the instance.
 
 > &#x26a0; You can use any GPU flavour to host the `text2img` project, but if opting for **g1.\*** make sure to skip the "Upgrading CUDA Version" step
 
-Attach a volume to your instance, at least 80 GB (ideally 100 GB) using the instructions [here.](https://wiki.cybera.ca/display/RAC/Rapid+Access+Cloud+Guide%3A+Part+1#RapidAccessCloudGuide:Part1-Volumes)
+Attach a volume to your instance, at least 80 GB (ideally 100 GB) using the instructions <a href="https://wiki.cybera.ca/display/RAC/Rapid+Access+Cloud+Guide%3A+Part+1#RapidAccessCloudGuide:Part1-Volumes" target="_blank">here</a>.
 
 ### 2. Install Docker
 
-Paste the following script ([from Docker installation website](https://docs.docker.com/engine/install/ubuntu/)) into an `install_docker.sh` file:
+Paste the following script (<a href="https://docs.docker.com/engine/install/ubuntu/" target="_blank">from Docker installation website</a>) into an `install_docker.sh` file:
 
 ```shell
 # Add Docker's official GPG key:
@@ -126,7 +126,7 @@ To upgrade CUDA to version 12.3 on **Ubuntu 20.04** OS please follow these steps
 sudo apt-get --purge remove "*nvidia*"
 ```
 
-3. Find the driver needed on the [NVIDIA drivers page](https://www.nvidia.com/en-us/drivers/unix/). The link "Latest Production Branch Version: 535.146.02" will yield CUDA version 12.3 (latest as of writing, January 2024). Place the downloaded file onto your machine.
+3. Find the driver needed on the <a href="https://www.nvidia.com/en-us/drivers/unix/" target="_blank">NVIDIA drivers page</a>. The link "Latest Production Branch Version: 535.146.02" will yield CUDA version 12.3 (latest as of writing, January 2024). Place the downloaded file onto your machine.
 4. Install the driver and CUDA with:
 
 ```shell
@@ -136,7 +136,7 @@ sudo ./NVIDIA-Linux-x86_64-535.146.02.run
 
 ### 5. Install CUDA Toolkit
 
-Install the CUDA toolkit by following the steps in 'Installing with Apt' and then the steps in 'Configuring Docker' sections found on the [NVIDIA website](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+Install the CUDA toolkit by following the steps in 'Installing with Apt' and then the steps in 'Configuring Docker' sections found on the <a href="https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html" target="_blank">NVIDIA website</a>.
 
 Configure the production repository:
 
@@ -193,9 +193,9 @@ or create a `.env` file in the same level as the `docker-compose.yml` file and p
 AUTH_TOKEN='<hugging face token>'
 ```
 
-into it. If following this approach, remember to `source` to restart your shell, or open a new terminal.
+into it.
 
-Note: If this is your first time using Hugging Face models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`.
+Note: If this is your first time using Hugging Face models, please make sure to go through <a href="https://huggingface.co/docs/hub/security-tokens" target="_blank">the documentation</a> and generate a user access token with the scope as `read`.
 
 Then, get the running instance of all the docker services by
 
@@ -219,7 +219,7 @@ After the succesful build, we can access the running services using the followin
 
 ### References
 
-1. [Set up Your own GPU-based Jupyter easily using Docker](https://cschranz.medium.com/set-up-your-own-gpu-based-jupyterlab-e0d45fcacf43)
-2. [Stable Diffusion with 🧨 Diffusers](https://huggingface.co/blog/stable_diffusion)
-3. [DeepLearning AI: FastAPI for Machine Learning: Live coding an ML web application](https://www.youtube.com/watch?v=_BZGtifh_gw)
-4. [Rombach, Robin, et al. "High-resolution image synthesis with latent diffusion models." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2022.](https://arxiv.org/abs/2112.10752)
+1. <a href="https://cschranz.medium.com/" target="_blank">Set up Your own GPU-based Jupyter easily using Docker<a/>
+2. <a href="https://huggingface.co/blog/stable_diffusion" target="_blank">Stable Diffusion with 🧨 Diffusers</a>
+3. <a href="https://www.youtube.com/watch?v=_BZGtifh_gw" target="_blank">DeepLearning AI: FastAPI for Machine Learning: Live coding an ML web application</a>
+4. <a href="https://arxiv.org/abs/2112.10752" target="_blank">Rombach, Robin, et al. "High-resolution image synthesis with latent diffusion models." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2022.</a>

--- a/README.md
+++ b/README.md
@@ -6,20 +6,24 @@ This workshop utilizes the stable diffusion method to generate images from text 
 
 This guide is organized as:
 
-1. Start a Rapid Access Cloud (RAC) GPU instance
+1. Start a Rapid Access Cloud (RAC) GPU instance and setup volume
 2. Install Docker
-3. Setup a volume on a RAC GPU instance to ensure adequate disk space
-4. Upgrade CUDA version (optional)
+3. Attach volume on a RAC GPU instance to ensure adequate disk space
+4. Upgrade CUDA version (optional for g2.* and g3.* instances)
 5. Install CUDA toolkit
 6. Start the jupyter, fastapi, and streamlit services
 
-### Start a Rapid Access Cloud (RAC) GPU instance
+### 1. Start a Rapid Access Cloud (RAC) GPU instance
 
-Sing up for a RAC account from https://rac-portal.cybera.ca/users/sign_in. Launch a RAC GPU instance and ensure you are able to use `$ ssh` to access the instance.
+Sign up for a RAC account from the [RAC portal](https://rac-portal.cybera.ca/users/sign_in). Ensure you're accessing RAC from the Edmonton region, then Launch a RAC GPU instance and ensure you are able to use `$ ssh` to access the instance.
 
-### Install Docker
+> &#x26a0; You can use any GPU flavour to host the `text2img` project, but if opting for **g1.\*** make sure to skip the "Upgrading CUDA Version" step
 
-Paste the following script (found at https://docs.docker.com/engine/install/ubuntu/) into an `install_docker.sh` file:
+Attach a volume to your instance, at least 80 GB (ideally 100 GB) using the instructions [here.](https://wiki.cybera.ca/display/RAC/Rapid+Access+Cloud+Guide%3A+Part+1#RapidAccessCloudGuide:Part1-Volumes)
+
+### 2. Install Docker
+
+Paste the following script ([from Docker installation website](https://docs.docker.com/engine/install/ubuntu/)) into an `install_docker.sh` file:
 
 ```shell
 # Add Docker's official GPG key:
@@ -49,11 +53,11 @@ sudo usermod -aG docker $USER
 newgrp docker
 ```
 
-### Setup a volume on a RAC
+### 3. Setup a volume on a RAC
 
-Volumes are setup to ensure additional disk space. RAC instances come with 40 GB of disk space by default.
+Volumes are setup to ensure additional disk space. RAC instances come with 40 GB of disk space by default, but these images will require more space to build.
 
-In the RAC console, under 'Volumes', create a volume wuth 80-100 GBs of space and attach it to the GPU instance.
+If you haven't yet, return to the [setup instructions](#1-start-a-rapid-access-cloud-rac-gpu-instance) to mount an adequate volume to your instance.
 
 Format the volume:
 
@@ -67,7 +71,7 @@ List all disks from within the instance with:
 sudo fdisk -l
 ```
 
-Look for the disk corresponding to the volume with the assigned amount of space. It will be either `/dev/sdb` or `/dev/sdc`. Remember whether 'b' or 'c' applies here.
+Look for the disk corresponding to the volume with the assigned amount of space. It will be either `/dev/sdb` or `/dev/sdc`. Remember whether 'b' or 'c' applies here, and use that in place of `<mount_point_name>` below.
 
 Create a mount point for the volume: 
 
@@ -75,10 +79,10 @@ Create a mount point for the volume:
 sudo mkdir /mnt/<mount_point_name>
 ```
 
-Mount the volume device to the mount point (replace `sdb` with `sdc` as needed):
+Mount the volume device to the mount point:
 
 ```shell
-sudo mount /dev/sdb /mnt/<mount_point_name>
+sudo mount /dev/sd<mount_point_name> /mnt/<mount_point_name>
 ```
 
 Permissions may need to be changed on the new volume, as they are initially set to root: 
@@ -87,7 +91,7 @@ Permissions may need to be changed on the new volume, as they are initially set 
 sudo chown ubuntu:ubuntu /mnt/<mount_point_name>
 ```
 
-In order to make sure docker data is stored on the new mount, create a `daemon.json` file in the `/etc/docker` directory and paste the following into it:
+In order to make sure Docker data is stored on the new mount, we'll have to create a new file that points to the attached volume. First, using either `chmod` or `sudo`, give yourself permission to create a new file, and create `daemon.json` file in the `/etc/docker` directory and paste the following into it.
 
 ```shell
 {
@@ -101,9 +105,9 @@ You must then restart the docker service with:
 sudo service docker restart
 ```
 
-### Upgrading CUDA Version (optional)
+### 4. Upgrading CUDA Version (optional)
 
-The code in the repository is setup to run for CUDA versions below 11.6 and this section can be skipped.
+> &#x26a0; This section can optionally be done for g2.\* and g3.\* instances and will improve performance, but needs to be skipped for g1.\* instances.
 
 Upgrading the CUDA version may enable running newer images on the RAC GPU instance. 
 
@@ -115,7 +119,7 @@ To upgrade the CUDA version on a Linux machine please follow these general steps
 
 To upgrade CUDA to version 12.2 on **Ubuntu 20.04** OS please follow these steps:
 
-1. Run `$ nvidia-smi` command to check for CUDA version.
+1. Run `$ nvidia-smi` command to check for CUDA version (should be 10.1)
 2. Delete an old NVIDIA installation with
 
 ```shell
@@ -130,7 +134,7 @@ chmod +x NVIDIA-Linux-x86_64-535.113.01.run
 sudo ./NVIDIA-Linux-x86_64-535.113.01.run
 ```
 
-### Install CUDA Toolkit
+### 5. Install CUDA Toolkit
 
 Install the CUDA toolkit by following the steps in 'Installing with Apt' and then the steps in 'Configuring Docker' sections found at https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
@@ -167,11 +171,17 @@ Restart the Docker daemon:
 sudo systemctl restart docker
 ```
 
-Run `$ nvidia-smi` command to check for the new CUDA version.
+Run `$ nvidia-smi` command to check for the new CUDA version to ensure it's been upgraded.
 
-### Start the jupyter, fastapi, and streamlit services
+### 6. Start the jupyter, fastapi, and streamlit services
 
-First, please source the HuggingFace AUTH_TOKEN as an environment variable in your terminal 
+Clone the repo into your VM:
+
+```shell
+git clone https://github.com/cybera/text2img.git
+```
+
+Source the HuggingFace AUTH_TOKEN as an environment variable in your terminal 
 ```
 export AUTH_TOKEN=''
 ```
@@ -182,7 +192,7 @@ or create a `.env` file in the same level as the `docker-compose.yml` file and p
 AUTH_TOKEN='<hugging face token>'
 ```
 
-into it.
+into it. If following this approach, remember to `source` to restart your shell, or open a new terminal.
 
 Note: If this is your first time using HuggingFace models, please make sure to go through [the documentation](https://huggingface.co/docs/hub/security-tokens) and generate a user access token with the scope as `read`. 
 
@@ -210,4 +220,4 @@ After the succesful build, we can access the running services using the followin
 1. [Set up Your own GPU-based Jupyter easily using Docker](https://cschranz.medium.com/set-up-your-own-gpu-based-jupyterlab-e0d45fcacf43)
 2. [Stable Diffusion with 🧨 Diffusers](https://huggingface.co/blog/stable_diffusion)
 3. [DeepLearning AI: FastAPI for Machine Learning: Live coding an ML web application](https://www.youtube.com/watch?v=_BZGtifh_gw)
-4. Rombach, Robin, et al. "High-resolution image synthesis with latent diffusion models." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2022.
+4. [Rombach, Robin, et al. "High-resolution image synthesis with latent diffusion models." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2022.](https://arxiv.org/abs/2112.10752)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To upgrade the CUDA version on a Linux machine please follow these general steps
 
 To upgrade CUDA to version 12.3 on **Ubuntu 20.04** OS please follow these steps:
 
-1. Run `$ nvidia-smi` command to check for CUDA version (should be 10.1)
+1. Run `$ nvidia-smi` command to check for CUDA version (should be 11.1)
 2. Delete an old NVIDIA installation with
 
 ```shell

--- a/app/app.py
+++ b/app/app.py
@@ -7,7 +7,7 @@ import plotly.express as px
 def main():
     st.title("Text2Img: Stable Diffusion App")
     st.info(
-        "Source: [HuggingFace Stable Diffusion with Diffusers blog](https://huggingface.co/blog/stable_diffusio)."
+        "Source: [HuggingFace Stable Diffusion with Diffusers blog](https://huggingface.co/blog/stable_diffusion)."
     )
 
     with st.form("my_form"):

--- a/docker/jupyterlab/requirements.txt
+++ b/docker/jupyterlab/requirements.txt
@@ -2,3 +2,5 @@ diffusers==0.14.0
 transformers 
 ftfy 
 accelerate
+typing-extensions>4
+torch==1.8.0


### PR DESCRIPTION
In addition to the more explicit instructions in the README, I had to roll back torch to 1.8.0 and enforce a newer version of typing-extensions. Seems to work well in both Jupyter and Streamlit now, only throwing soft errors about configuration and FutureWarnings 